### PR TITLE
Move getJoke() to node_helper to prevent error 401/cors error

### DIFF
--- a/MMM-BlaguesAPI.js
+++ b/MMM-BlaguesAPI.js
@@ -11,13 +11,17 @@ Module.register("MMM-BlaguesAPI", {
     },
     joke: null,
     notificationReceived(notification, payload, sender) {
-        if (notification === 'MODULE_DOM_CREATED') {
-            this.getJoke();
-            setInterval(() => {
-                this.getJoke()
-            }, this.config.fetchInterval);
-        }
+      if (notification === 'MODULE_DOM_CREATED') {
+        this.sendSocketNotification("INIT", this.config);
+      }
     },
+    socketNotificationReceived(notification, payload) {
+      if (notification === "JOKE") {
+        this.joke = payload;
+        this.updateDom();
+      }
+    },
+
     getDom() {
         const wrapper = document.createElement("div");
 
@@ -37,26 +41,5 @@ Module.register("MMM-BlaguesAPI", {
         reply.className = "bright medium light fadeInReply";
         reply.innerHTML = this.joke.answer;
         wrapper.appendChild(reply);
-    },
-    getJoke() {
-        Log.info("getJoke");
-        let apiUrl;
-        if (this.config.type === 'random') {
-            apiUrl = 'https://www.blagues-api.fr/api/random';
-        } else {
-            apiUrl = `https://www.blagues-api.fr/api/type/${this.config.type}/random`;
-        }
-        fetch(apiUrl, {
-            method: 'get',
-            headers: new Headers({
-                'Authorization': 'Bearer ' + `${this.config.blaguesApiToken}`,
-                'Content-Type': 'application/x-www-form-urlencoded'
-            })
-        }).then((response) => {
-            response.json().then((joke) => {
-                this.joke = joke;
-                this.updateDom();
-            });
-        });
     }
 });

--- a/node_helper.js
+++ b/node_helper.js
@@ -1,0 +1,39 @@
+"use strict"
+
+var NodeHelper = require("node_helper")
+
+module.exports = NodeHelper.create({
+  socketNotificationReceived: function (noti, payload) {
+    switch (noti) {
+      case "INIT":
+        console.log("[JOKE] MMM-BlaguesAPI Version:", require('./package.json').version)
+        this.config = payload
+        this.getJoke();
+        setInterval(() => {
+          this.getJoke();
+        }, this.config.fetchInterval);
+        break
+    }
+  },
+  getJoke() {
+      console.info("getJoke");
+      let apiUrl;
+      if (this.config.type === 'random') {
+          apiUrl = 'https://www.blagues-api.fr/api/random';
+      } else {
+          apiUrl = `https://www.blagues-api.fr/api/type/${this.config.type}/random`;
+      }
+      fetch(apiUrl, {
+          method: 'get',
+          headers: new Headers({
+              'Authorization': 'Bearer ' + `${this.config.blaguesApiToken}`,
+              'Content-Type': 'application/x-www-form-urlencoded'
+          })
+      }).then((response) => {
+          response.json().then((joke) => {
+              this.sendSocketNotification("JOKE", joke);
+          });
+      });
+  }
+
+})

--- a/node_helper.js
+++ b/node_helper.js
@@ -16,7 +16,7 @@ module.exports = NodeHelper.create({
     }
   },
   getJoke() {
-      console.info("getJoke");
+      //console.info("getJoke");
       let apiUrl;
       if (this.config.type === 'random') {
           apiUrl = 'https://www.blagues-api.fr/api/random';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "mmm-blaguesapi",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mmm-blaguesapi",
+      "version": "1.0.0",
+      "license": "MIT"
+    }
+  }
+}


### PR DESCRIPTION
Hi, I have an isssue with MM² v2.28.0,
I'm not able to display any joke :/
there is an CORS error or error 401 (sometime)

So I have move `getJoke()` function to node_helper for working (best way)

If you have the same problem, i share you my code, i don't hesitate to modify it before pushing it

@bugsounet
